### PR TITLE
Refactor How Corrupt Key Is Generated In Report Object

### DIFF
--- a/utils/compareObjects.js
+++ b/utils/compareObjects.js
@@ -7,6 +7,11 @@ const ifObjectsContainSameContent = (obj1, obj2) => {
   return true;
 };
 
+const differentColumns = (oldDBColumns, newDBColumns) => {
+  return newDBColumns.filter(x => oldDBColumns.indexOf(x) === -1);
+}
+
 module.exports = {
   ifObjectsContainSameContent,
+  differentColumns,
 };

--- a/utils/compareObjects.test.js
+++ b/utils/compareObjects.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('@jest/globals');
-const { ifObjectsContainSameContent } = require('./compareObjects');
+const { ifObjectsContainSameContent, differentColumns } = require('./compareObjects');
 
 describe('Compare Object Functions', () => {
   describe('ifObjectsContainSameContent', () => {
@@ -28,6 +28,20 @@ describe('Compare Object Functions', () => {
 
       expect(result1).toBe(false);
       expect(result2).toBe(false);
+    });
+  });
+
+  describe('differentColumns', () => {
+    it('should return the difference between 2 arrays', () => {
+      const arr1 = ['id', 'name', 'email'];
+      const arr2 = ['id', 'name', 'email', 'favorite_flavor'];
+      const arr3 = ['id'];
+
+      const difference1 = differentColumns(arr1, arr2)
+      const difference2 = differentColumns(arr3, arr1)
+
+      expect(difference1).toEqual(expect.arrayContaining(['favorite_flavor']));
+      expect(difference2).toEqual(expect.arrayContaining(['name', 'email']));
     });
   });
 });

--- a/utils/createReport.js
+++ b/utils/createReport.js
@@ -1,10 +1,11 @@
 const { ifObjectsContainSameContent } = require('./compareObjects');
 
-const addToCorrupt = (objReport, objCorruptValues, objActualValues, primaryKey) => {
-  objReport.corrupt[primaryKey] = {
-    corruptValues: objCorruptValues,
-    actualValues: objActualValues,
-  };
+const addToCorrupt = (objReport, oldDBObject, newDBObject, primaryKey, differentColumns) => {
+  objReport.corrupt[primaryKey] = { ...oldDBObject[primaryKey] };
+
+  differentColumns.map((colName) => {
+    objReport.corrupt[primaryKey][colName] = newDBObject[primaryKey][colName];
+  });
 };
 
 const addToMissing = (objReport, objMain, primaryKey) => {

--- a/utils/createReport.js
+++ b/utils/createReport.js
@@ -12,7 +12,7 @@ const addToMissing = (objReport, objMain, primaryKey) => {
   objReport.missing[primaryKey] = objMain[primaryKey];
 };
 
-const createReportObject = (oldDBObject, newDBObject) => {
+const createReportObject = (oldDBObject, newDBObject, differentColumns = []) => {
   const reportObject = {
     corrupt: {},
     missing: {},
@@ -22,16 +22,7 @@ const createReportObject = (oldDBObject, newDBObject) => {
   for (let primaryKey in oldDBObject) {
     if (newDBObject[primaryKey]) {
       if (!ifObjectsContainSameContent(oldDBObject[primaryKey], newDBObject[primaryKey])) {
-        const corruptValues = {};
-        const actualValues = {};
-
-        for (let field in oldDBObject[primaryKey]) {
-          if (oldDBObject[primaryKey][field] !== newDBObject[primaryKey][field]) {
-            corruptValues[field] = newDBObject[primaryKey][field];
-            actualValues[field] = oldDBObject[primaryKey][field];
-          }
-        }
-        addToCorrupt(reportObject, corruptValues, actualValues, primaryKey);
+        addToCorrupt(reportObject, oldDBObject, newDBObject, primaryKey, differentColumns);
       }
       delete newDBObject[primaryKey];
     } else {

--- a/utils/createReport.test.js
+++ b/utils/createReport.test.js
@@ -7,64 +7,23 @@ const {
 
 describe('Report Creating Functions', () => {
   describe('addToCorrupt', () => {
-    it(`should add a key to 'corrupt' key in objReport argument with the value of an object`, () => {
+    it(`should add a key to 'corrupt' key and put in actual values that it should contain`, () => {
+      const oldDBObject = { '1': { name: '1', email: '1' } }
+      const newDBObject = { '1': { name: '1', email: '2', extra: '1' } }
+      const differntColumns = ['extra'];
+
       const reportObject = {
         corrupt: {},
       };
-      const objCorruptValues1 = { name: 'John' };
-      const objActualValues1 = { name: 'Sam' };
-      const primaryKey1 = '1';
 
-      addToCorrupt(reportObject, objCorruptValues1, objActualValues1, primaryKey1)
-
-      expect(Object.keys(reportObject.corrupt)).toEqual(expect.arrayContaining(['1']));
-      expect(Object.keys(reportObject.corrupt).length).toBe(1);
-      expect(typeof reportObject.corrupt['1']).toBe('object');
-      expect(Array.isArray(reportObject.corrupt['1'])).toBe(false);
-
-      const objCorrupt2 = { name: 'Mary' };
-      const objActualValues2 = { name: 'Tom' };
-      const primaryKey2 = '2';
-
-      addToCorrupt(reportObject, objCorrupt2, objActualValues2, primaryKey2)
-
-      expect(Object.keys(reportObject.corrupt)).toEqual(expect.arrayContaining(['1', '2']));
-      expect(Object.keys(reportObject.corrupt).length).toBe(2);
-    });
-
-    it(`should add an object with a corrupt and actual key for each primary key added to 'corrupt' key`, () => {
-      const reportObject = {
-        corrupt: {},
-      };
-      const objCorruptValues1 = { name: 'John', email: '123' };
-      const objActualValues1 = { name: 'Sam', email: '456' };
-      const primaryKey1 = '1';
-
-      addToCorrupt(reportObject, objCorruptValues1, objActualValues1, primaryKey1)
-
-      const objCorrupt2 = { name: 'Mary' };
-      const objActualValues2 = { name: 'Tom' };
-      const primaryKey2 = '2';
-
-      addToCorrupt(reportObject, objCorrupt2, objActualValues2, primaryKey2)
-
-      const expectedResult = {
+      const expected = {
         corrupt: {
-          '1': {
-            corruptValues: { name: 'John', email: '123' },
-            actualValues: { name: 'Sam', email: '456' },
-          },
-          '2': {
-            corruptValues: { name: 'Mary' },
-            actualValues: { name: 'Tom' },
-          },
-        },
+          '1': { name: '1', email: '1', extra: '1' }
+        }
       };
 
-      expect(reportObject.corrupt['1'].corruptValues).toMatchObject(expectedResult.corrupt['1'].corruptValues);
-      expect(reportObject.corrupt['1'].actualValues).toMatchObject(expectedResult.corrupt['1'].actualValues);
-      expect(reportObject.corrupt['2'].corruptValues).toMatchObject(expectedResult.corrupt['2'].corruptValues);
-      expect(reportObject.corrupt['2'].actualValues).toMatchObject(expectedResult.corrupt['2'].actualValues);
+      addToCorrupt(reportObject, oldDBObject, newDBObject, '1', differntColumns);
+      expect(reportObject).toEqual(expected);
     });
   });
 

--- a/utils/createReport.test.js
+++ b/utils/createReport.test.js
@@ -116,9 +116,9 @@ describe('Report Creating Functions', () => {
 
       const expectedReportObject = {
         corrupt: {
-          '1': { corruptValues: { email: '2' }, actualValues: { email: '1' } },
-          '2': { corruptValues: { name: '1' }, actualValues: { name: '2' } },
-          '3': { corruptValues: { name: '4', email: '4' }, actualValues: { name: '3', email: '3' } },
+          '1': { name: '1', email: '1' },
+          '2': { name: '2', email: '2' },
+          '3': { name: '3', email: '3' },
         },
         missing: {},
         new: {},
@@ -145,9 +145,9 @@ describe('Report Creating Functions', () => {
 
       const expectedReportObject = {
         corrupt: {
-          '1': { corruptValues: { email: '2' }, actualValues: { email: '1' } },
-          '2': { corruptValues: { name: '1' }, actualValues: { name: '2' } },
-          '3': { corruptValues: { name: '4', email: '4' }, actualValues: { name: '3', email: '3' } },
+          '1': { name: '1', email: '1' },
+          '2': { name: '2', email: '2' },
+          '3': { name: '3', email: '3' },
         },
         missing: {
           '4': { name: '4', email: '4' },
@@ -175,13 +175,13 @@ describe('Report Creating Functions', () => {
         '6': { name: '6', email: '6', extra: '5' },
       };
 
-      const testReport = createReportObject(testOldDB, testNewDB);
+      const testReport = createReportObject(testOldDB, testNewDB, ['extra']);
 
       const expectedReportObject = {
         corrupt: {
-          '1': { corruptValues: { email: '2' }, actualValues: { email: '1' } },
-          '2': { corruptValues: { name: '1' }, actualValues: { name: '2' } },
-          '3': { corruptValues: { name: '4', email: '4' }, actualValues: { name: '3', email: '3' } },
+          '1': { name: '1', email: '1', extra: '1' },
+          '2': { name: '2', email: '2', extra: '2' },
+          '3': { name: '3', email: '3', extra: '3' },
         },
         missing: {
           '4': { name: '4', email: '4' },


### PR DESCRIPTION
Since the `corrupt` key in the `reportObject` had keys with objects as values, I had difficulty determining how I could use that to generate a useful report (I intended to generate a CSV file and since the values were objects, it could be complicated). Instead, I refactored it so that the `corrupt` key now only contains the old database fields as those are the actual values anyway (displaying the corrupted values may have been irrelevant). I also tacked on the extra fields onto that object in the case of the new database having extra fields. This way, I can generate a useful CSV file as a report containing what the primary key fields should be.